### PR TITLE
Mise à jour utilisation Apicarto-cadastre avec WFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,87 @@
+
+# Installation des dépendances NodeJS
+
+```
+npm install
+```
+
+# Exécution du service
+
+```
+nodejs index.js --key [VOTRE_CLE_GEOPORTAIL] --referer [REFEREF_DE_LA_CLE]
+```
+Exemple :
+
+```
+node index.js --key 5ad45a4d54a5d4a5d4ad --referer "http://mborne.github.io"
+```
+
+Autres options :
+
+* Définir le port HTTP
+
+
+* Proxy entre NodeJS et les services géoportail (http://wxs.ign.fr)
+
+--proxy=http://[proxy-host]:[proxy-port]
+
+# API
+
+## Récupérer les sections pour une communes
+
+```
+GET /section?code_dep=25&code_com=349
+```
+
+Résultat : FeatureCollection GeoJSON
+
+## Récupérer les parcelles pour une section
+
+```
+GET /parcelle?code_dep=25&code_com=349&
+```
+
+Résultat : FeatureCollection GeoJSON
+
+### Récuper les informations parcelles et calcul de surface via une geometrie
+GET /geometrie?geom=FeatureCollection.
+Exemple : 
+{
+    "type":"Feature",
+    "geometry":
+		{"type":
+    "Polygon",
+    "coordinates":[[[4.79628704723532,45.2245686201141],[4.79627198205696,45.2244810075761],[4.79623301978841,45.2243971554783],[4.7961716578197,45.2243202861855],
+    [4.7960902543159,45.2242533537068],[4.79599193758517,45.2241989301793],[4.795880485857,45.2241591070292],[4.79576018209113,45.2241354146047],
+    [4.79563564939616,45.2241287633715],[4.79551167338089,45.2241394089266],[4.79539301826325,45.224166942177],[4.79528424380096,45.2242103050595],
+    [4.79518953007658,45.2242678311979],[4.79511251686827,45.2243373099351],[4.79505616377777,45.224416071282],[4.79502263649038,45.224501088517],
+    [4.79501322353864,45.2245890944965],[4.79502828676983,45.2246767072062],[4.79506724742323,45.2247605597291],[4.7951286083547,45.2248374296355],
+    [4.79521001155707,45.2249043628231],[4.79530832876809,45.2249587870468],[4.79541978168514,45.2249986107744],[4.79554008716747,45.2250223035697],
+    [4.79566462184518,45.2250289549107],[4.79578859980762,45.2250183091839],[4.79590725654041,45.2249907755084],[4.79601603203994,45.2249474120122],[
+    4.79611074606575,45.2248898851649],[4.79618775879377,45.2248204057315],[4.7962441106954,45.2247416438072],[4.79627763626632,45.2246566262013],
+    [4.79628704723532,45.2245686201141]]]}
+ }
+
+
+# Obtenir une clé géoportail
+
+TODO : détailler le processus pour les clés WFS
+
+# Notes techniques
+
+Ce service se repose sur l'appel à des services WFS de l'API géoportail
+
+## Service WFS
+
+
+* Récupérer les divisions cadastrales (couple=> autocomplétion sur section et commune absorbée)
+
+http://wxs.ign.fr/[API_KEY]/geoportail/wfs?
+request=GetFeature&version=2.0.0
+&typename=BDPARCELLAIRE-VECTEUR_WLD_BDD_WGS84G:divcad
+&outputFormat=application/json
+&cql_filter=code_dep=25%20and%20code_com=349
+
+* Recherche d'une parcelle précise
+
+http://wxs.ign.fr/[API_KEY]/geoportail/wfs?request=GetFeature&version=2.0.0&typename=BDPARCELLAIRE-VECTEUR_WLD_BDD_WGS84G:parcelle&CountDefault=100&outputFormat=application/json&cql_filter=code_dep=25%20and%20code_com=349

--- a/lib/CadastreClient.js
+++ b/lib/CadastreClient.js
@@ -1,0 +1,159 @@
+var request = require('request');
+
+var geojson_flip_lonlat = require('../lib/geojson_flip_lonlat.js') ;
+var geom_featureCollection = require('../lib/geom_featurecollection.js') ;
+var cql_filter = require("./cql_filter");
+var turf = require('turf');
+var util = require("util");
+
+function FeatureCollection() {
+  this.type = 'FeatureCollection';
+  this.features = new Array();
+}
+
+/**
+ * Constructeur avec :
+ * apiKey : une clé IGN avec les droits sur BDPARCELLAIRE-VECTEUR_WLD_BDD_WGS84G:divcad et BDPARCELLAIRE-VECTEUR_WLD_BDD_WGS84G:parcelle
+ * referer : le referer correspondant à la clée
+ */
+var CadastreClient = function(apiKey,referer){
+    this.apiKey = apiKey ;
+    this.referer = referer || "http://localhost" ;
+    this.proxy = null ;
+}
+
+CadastreClient.prototype.getProxy = function(){
+    return this.proxy ;
+}
+
+CadastreClient.prototype.setProxy = function(proxy){
+    this.proxy = proxy ;
+}
+
+
+/**
+ * URL vers le service WFS
+ */
+CadastreClient.prototype.getBaseUrl = function(){
+    return "http://wxs.ign.fr/"+this.apiKey+"/geoportail/wfs";
+}
+
+CadastreClient.prototype.getDefaultOptions = function(){
+    return {
+        uri: this.getBaseUrl(),
+        headers: {
+            'Referer': this.referer
+        },
+        proxy: this.proxy
+    };
+}
+
+
+CadastreClient.prototype.getCapabilities = function(callback){
+    var options = this.getDefaultOptions();
+    options.uri += "?request=GetCapabilities" ;
+    request(options, function(error, response, body) {
+        if (!error && response.statusCode == 200) {
+            callback(body);
+        }else{
+            callback(null);
+        }
+    });
+}
+
+
+
+/**
+ * Récupération des communes pour un code département et un code commune
+ */
+CadastreClient.prototype.getDivisions = function(params, callback){
+    var options = this.getDefaultOptions();
+    options.uri += "?request=GetFeature&version=2.0.0" ;
+    options.uri += "&typename=BDPARCELLAIRE-VECTEUR_WLD_BDD_WGS84G:divcad" ;
+    options.uri += "&outputFormat="+encodeURIComponent("application/json") ;
+    options.uri += "&cql_filter="+encodeURIComponent(cql_filter(params));
+
+    console.log( options.uri ) ;
+
+    request(options, function(error, response, body) {
+        if (!error && response.statusCode == 200) {
+            try {
+                callback(JSON.parse(body));
+            }catch(err){
+                console.log(body);
+                callback(null);
+            }
+        }else{
+            callback(null);
+        }
+    });
+}
+
+
+/**
+ * Récupération des parcelles
+ */
+CadastreClient.prototype.getParcelles = function(params, callback){
+    var options = this.getDefaultOptions();
+    options.uri += "?request=GetFeature&version=2.0.0" ;
+    options.uri += "&typename=BDPARCELLAIRE-VECTEUR_WLD_BDD_WGS84G:parcelle" ;
+    options.uri += "&outputFormat="+encodeURIComponent("application/json") ;
+    options.uri += "&cql_filter="+encodeURIComponent(cql_filter(params));
+	
+    console.log( options.uri ) ;
+
+   request(options, function(error, response, body) {
+        if (!error && response.statusCode == 200) {
+            try {
+				var geojson = geojson_flip_lonlat(JSON.parse(body));
+				
+				callback(geojson);
+            }catch(err){
+                console.log(err);
+                callback(null);
+            }
+        }else{
+            callback(null);
+        }
+    });
+}
+
+
+/* Recuperer les informations du cadastre à partir d'une geometrie
+ * le résultat retourne :
+ * Informations sur la parcelle
+ * Calcul des surfaces et des intersections
+ */
+ 
+ CadastreClient.prototype.getCadastreFromGeom = function(params, callback){
+    var options = this.getDefaultOptions();
+    var paramsGeom = {
+			geom: params.geometry
+		};
+    options.uri += "?request=GetFeature&version=2.0.0" ;
+    options.uri += "&typename=BDPARCELLAIRE-VECTEUR_WLD_BDD_WGS84G:parcelle" ;
+    options.uri += "&outputFormat="+encodeURIComponent("application/json") ;
+
+	options.uri += "&cql_filter="+encodeURIComponent(cql_filter(paramsGeom));
+	console.log(options.uri);
+	var geoInitialParams = params;
+	var featureCollection = new FeatureCollection();
+	request(options, function(error, response, body) {
+        if (!error && response.statusCode == 200) {
+            try {
+				var geojson = geojson_flip_lonlat(JSON.parse(body));
+				
+				var resultatGeom = geom_featureCollection(geojson, geoInitialParams);
+				callback(resultatGeom);
+            }catch(err){
+                console.log(err);
+                callback(null);
+            }
+        }else{
+            callback(null);
+        }
+    });
+}
+
+
+module.exports = CadastreClient ;

--- a/lib/cql_filter.js
+++ b/lib/cql_filter.js
@@ -1,0 +1,19 @@
+var WKT = require('terraformer-wkt-parser');
+var util = require("util");
+
+module.exports =  function(params){
+    var parts = [] ;
+    for ( var name in params ){
+        if ( name == 'bbox' ){
+			// hack (strange "'" added around bbox)
+            params[name] = params[name].replace(/'/g, ""); 
+            parts.push( "BBOX(the_geom,"+params[name]+")" ) ;
+        }else if ( name == 'geom' ){
+			wkt = WKT.convert(params[name]);
+			parts.push( util.format("INTERSECTS(the_geom,%s)",wkt) );
+		}else{
+            parts.push( name+"="+params[name] );
+        }
+    }
+    return parts.join(" and ") ;
+}

--- a/lib/geojson_flip_lonlat.js
+++ b/lib/geojson_flip_lonlat.js
@@ -1,0 +1,83 @@
+
+
+function geojson_flip_lonlat_coordinate(coordinate){
+	if ( coordinate.length >= 2 ){
+		//console.log("Je suis dans les coordonnées");
+		var temp = coordinate[0];
+		coordinate[0] = coordinate[1] ;
+		coordinate[1] = temp ;
+	}	
+	return coordinate;
+}
+
+function geojson_flip_lonlat_coordinate_array_2(coordinates){
+	for ( var i in coordinates ){
+		//console.log("je suis dans boucle cordinates");console.log(i);
+		geojson_flip_lonlat_coordinate(coordinates[i]);
+	}
+}
+
+function geojson_flip_lonlat_coordinate_array_3(coordinates){
+	for ( var i in coordinates ){
+		//console.log("je suis dans boucle cordinates");console.log(i);
+		geojson_flip_lonlat_coordinate_array_2(coordinates[i]);
+	}
+}
+
+
+function geojson_flip_lonlat_coordinate_array_4(coordinates){
+	//console.log("je suis dans boucle cordinates4");
+	for ( var i in coordinates ){
+		geojson_flip_lonlat_coordinate_array_3(coordinates[i]);
+	}
+}
+
+
+function geojson_flip_lonlat_geometry(geometry){
+	if ( geometry["type"] == "Point" ){
+		geojson_flip_lonlat_coordinate(geometry["coordinates"]);
+	}else if ( geometry["type"] == "LineString" ){
+		geojson_flip_lonlat_coordinate_array_2(geometry["coordinates"]);
+		//console.log("Je suis dans orientation Ligne");
+	} else if ( geometry["type"] == "Polygon" ){
+		geojson_flip_lonlat_coordinate_array_3(geometry["coordinates"]);
+		//console.log("Je suis dans orientation Polygone");
+	} else if ( geometry["type"] == "MultiPolygon" ){
+		//console.log("je suis dans Multipolygon");
+		geojson_flip_lonlat_coordinate_array_4(geometry["coordinates"]);
+	}else{
+		throw "type géométrique non supporté : " + geometry["type"] ;
+	}
+	
+}
+
+function geojson_flip_lonlat_feature(feature){
+	geojson_flip_lonlat_geometry(feature["geometry"]);
+}
+
+
+function geojson_flip_lonlat_features(features){
+	for ( var i in features ){
+		geojson_flip_lonlat_feature(features[i]);
+	}
+}
+
+var geojson_flip_lonlat = function(geojson){
+	if ( geojson["type"] == "FeatureCollection" ){
+		geojson_flip_lonlat_features(geojson["features"]);
+	
+	}else if ( geojson["type"] == "Feature" ){
+		//console.log("je suis dans la feature");
+		geojson_flip_lonlat_feature(geojson);
+	
+	}else{
+		//console.log("Je suis dans la geometry")
+		geojson_flip_lonlat_geometry(geojson);
+	}
+	return geojson;
+}
+
+
+module.exports = geojson_flip_lonlat ;
+
+

--- a/lib/geom_featurecollection.js
+++ b/lib/geom_featurecollection.js
@@ -1,0 +1,41 @@
+/* Retourne un resultat FeatureCollection
+ * Recois en paramètre une geometrie
+ */
+ var WKT = require('terraformer-wkt-parser');
+ var turf = require('turf');
+var util = require("util");
+ 
+function FeatureCollection() {
+  this.type = 'FeatureCollection';
+  this.features = new Array();
+}
+ var geom_featureCollection= function(parcelles,paramInit){
+	 var featureCollection = new FeatureCollection();
+	var paramInitMod=  paramInit;
+	//console.log(paramInitMod);
+	 for (var i = 0, len = parcelles.features.length; i < len; i++) {
+		
+		parcelle = parcelles.features[i];
+		//console.log(parcelle);
+		//surface_intersection = (turf.area(turf.intersect(parcelle, paramInitMod)) / 10000).toFixed(4);
+		featureCollection.features[i] = {
+			type: "Feature",
+			geometry: parcelle.geometry,
+			properties: {
+			  //surface_intersection: surface_intersection,
+			  surface_parcelle: turf.area(parcelle),
+			  numero: parcelle.properties.numero,
+			  feuille: parcelle.properties.feuille,
+			  section: parcelle.properties.section,
+			  code_dep: parcelle.properties.code_dep,
+			  nom_com: parcelle.properties.nom_com,
+			  code_com: parcelle.properties.code_com,
+			  code_arr: parcelle.properties.code_arr
+			}
+		}
+	}
+	return featureCollection;
+}
+
+
+module.exports = geom_featureCollection ;

--- a/lib/parse_cadastre.js
+++ b/lib/parse_cadastre.js
@@ -1,0 +1,19 @@
+/* Nous verifons les champs :
+ * section sur 2 caractères
+ * numero sur 4 caractères
+ * 
+ */
+
+var parse_cadastre = function(cadastre,name){
+    if (name == "section") { value =2;}
+    else { value=4;}
+	console.log(name);console.log(value);
+	if ( cadastre.length !== value ){
+        return null ;
+    } 
+	return {
+            name: cadastre,
+        } ;
+}
+
+module.exports = parse_cadastre ;

--- a/lib/parse_insee.js
+++ b/lib/parse_insee.js
@@ -1,0 +1,18 @@
+var parse_insee = function(insee){
+    if ( insee.length !== 5 ){
+        return null ;
+    }
+    if ( insee.substr(0,2) == "97" ){
+        return {
+            code_dep: insee.substr(0,3),
+            code_com: insee.substr(3,2)
+        } ;
+    }else{
+        return {
+            code_dep: insee.substr(0,2),
+            code_com: insee.substr(2,3)
+        } ;
+    }
+}
+
+module.exports = parse_insee ;

--- a/lib/prepare_section_params.js
+++ b/lib/prepare_section_params.js
@@ -1,0 +1,70 @@
+var WKT = require('terraformer-wkt-parser');
+
+var parse_insee = require('./parse_insee');
+
+module.exports =  function(query){
+    var result = {} ;
+
+    for ( var name in query ){
+        if ( name == 'insee' ){
+            var inseeParts = parse_insee(query[name]) ;
+            if ( null !== inseeParts ){
+                result.code_dep = inseeParts.code_dep ;
+                result.code_com = inseeParts.code_com ;
+            }
+        } else if (name == 'geom') {
+			wkt = WKT.convert(query[name]);
+			console.log(wkt);
+			result.geom = "'"+wkt+"'";
+		} else {
+            result[name] = "'"+query[name]+"'" ;
+        }
+	} /* } else if ( name == 'section') {
+			 if (query[name].length !==2) {
+				 result.section = null;
+			 } else {
+				 result.section = query[name];
+			 }*/
+			 
+		/*} else if (name == 'numero') {
+			 if (query[name].length !==4) {
+				 result.numero = null;
+			 } else {
+				 result.numero = query[name];
+			 }*/
+	console.log(result);
+    return result ;
+}
+var parse_insee = require('./parse_insee');
+
+module.exports =  function(query){
+    var result = {} ;
+
+    for ( var name in query ){
+        if ( name == 'insee' ){
+            var inseeParts = parse_insee(query[name]) ;
+            if ( null !== inseeParts ){
+                result.code_dep = inseeParts.code_dep ;
+                result.code_com = inseeParts.code_com ;
+            }
+        } else if (name == 'geom') {
+			result.geom = "'"+query[name]+"'";
+		} else {
+            result[name] = "'"+query[name]+"'" ;
+        }
+	} /* } else if ( name == 'section') {
+			 if (query[name].length !==2) {
+				 result.section = null;
+			 } else {
+				 result.section = query[name];
+			 }*/
+			 
+		/*} else if (name == 'numero') {
+			 if (query[name].length !==4) {
+				 result.numero = null;
+			 } else {
+				 result.numero = query[name];
+			 }*/
+	console.log(result);
+    return result ;
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,26 @@
 {
- "name": "apicarto-cadastre",
- "version": "0.0.2",
- "description": "An interface for querying french cadastre.",
- "main": "index.js",
- "author": "Nabil Servais (SGMAP)",
- "private": true,
- "license": "MIT"
-} 
+  "name": "express-cadastre",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node_modules/.bin/mocha test/*.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.13.3",
+    "nconf": "^0.8.2",
+    "turf: "^2.0.2",
+    "util:"0.10.3",
+    "terraformer-wkt-parser:"1.0.1",
+    "request:"2.65.0",
+    "body-parser:"1.14.1"
+  },
+  "devDependencies": {
+    "mocha": "^2.3.3",
+    "unit.js": "^2.0.0",
+    
+    
+  }
+}

--- a/routes.js
+++ b/routes.js
@@ -1,0 +1,102 @@
+var prepare_section_params = require('./lib/prepare_section_params');
+var geojson_flip_lonlat = require('./lib/geojson_flip_lonlat.js');
+
+module.exports = function(app,cadastreClient){
+
+    app.get('/capabilities', function(req, res) {
+        cadastreClient.getCapabilities(function(body){
+            if ( body ){
+                //console.log(body);
+                res.set('Content-Type', 'text/xml');
+                res.send(body);
+            }else{
+                //console.log(body);
+                res.set('Content-Type', 'application/text');
+                res.send("Le service distant n'est pas disponible");
+            }
+        });
+    });
+
+    /**
+     * Récupération des divisions pour une commune.
+     *
+     * Paramètres : code_dep=25 et code_com=349
+     *
+     */
+    app.get('/cadastre/division', function(req,res){
+        var params = prepare_section_params(req.query);
+        console.log(JSON.stringify(params));
+        cadastreClient.getDivisions(params,function(featureCollection){
+            res.json(featureCollection);
+        }) ;
+    });
+
+
+    /**
+     * Récupération des divisions pour une commune.
+     *
+     * Paramètres : code_dep=25 et code_com=349
+     *
+     */
+    app.get('/cadastre/parcelle', function(req,res){
+        //TODO prepare_parcelle_params
+        var params = prepare_section_params(req.query);
+        console.log(params.bbox);
+        console.log(JSON.stringify(params));
+        cadastreClient.getParcelles(params,function(featureCollection){
+            res.json(featureCollection);
+        }) ;
+    });
+
+ /**
+     * Récupération des informations cadastre et commune
+     *
+     * Paramètres : une feature avec pour nom "geom"...
+     *
+     */
+     
+
+    app.get('/cadastre/geometrie', function(req,res){
+		/*var feature = {
+    "type":"Feature",
+    "geometry":
+		{"type":
+    "Polygon",
+    "coordinates":[[[4.79628704723532,45.2245686201141],[4.79627198205696,45.2244810075761],[4.79623301978841,45.2243971554783],[4.7961716578197,45.2243202861855],[4.7960902543159,45.2242533537068],[4.79599193758517,45.2241989301793],[4.795880485857,45.2241591070292],[4.79576018209113,45.2241354146047],[4.79563564939616,45.2241287633715],[4.79551167338089,45.2241394089266],[4.79539301826325,45.224166942177],[4.79528424380096,45.2242103050595],[4.79518953007658,45.2242678311979],[4.79511251686827,45.2243373099351],[4.79505616377777,45.224416071282],[4.79502263649038,45.224501088517],[4.79501322353864,45.2245890944965],[4.79502828676983,45.2246767072062],[4.79506724742323,45.2247605597291],[4.7951286083547,45.2248374296355],[4.79521001155707,45.2249043628231],[4.79530832876809,45.2249587870468],[4.79541978168514,45.2249986107744],[4.79554008716747,45.2250223035697],[4.79566462184518,45.2250289549107],[4.79578859980762,45.2250183091839],[4.79590725654041,45.2249907755084],[4.79601603203994,45.2249474120122],[4.79611074606575,45.2248898851649],[4.79618775879377,45.2248204057315],[4.7962441106954,45.2247416438072],[4.79627763626632,45.2246566262013],[4.79628704723532,45.2245686201141]]]}
+};*/
+		var feature = JSON.parse(req.query.geom);
+		
+		geojson_flip_lonlat(feature); //FIXME
+		console.log(feature);
+		/*var params = {
+			geom: feature.geometry
+		};*/
+		cadastreClient.getCadastreFromGeom(feature,function(featureCollection){
+            res.json(featureCollection);
+        }) ;
+		
+    });
+
+/*app.get('/cadastre/geometrie', function(req,res){
+		var feature = {
+    "type":"Feature",
+    "geometry":
+		{"type":
+    "Polygon",
+    "coordinates":[[[4.79628704723532,45.2245686201141],[4.79627198205696,45.2244810075761],[4.79623301978841,45.2243971554783],[4.7961716578197,45.2243202861855],[4.7960902543159,45.2242533537068],[4.79599193758517,45.2241989301793],[4.795880485857,45.2241591070292],[4.79576018209113,45.2241354146047],[4.79563564939616,45.2241287633715],[4.79551167338089,45.2241394089266],[4.79539301826325,45.224166942177],[4.79528424380096,45.2242103050595],[4.79518953007658,45.2242678311979],[4.79511251686827,45.2243373099351],[4.79505616377777,45.224416071282],[4.79502263649038,45.224501088517],[4.79501322353864,45.2245890944965],[4.79502828676983,45.2246767072062],[4.79506724742323,45.2247605597291],[4.7951286083547,45.2248374296355],[4.79521001155707,45.2249043628231],[4.79530832876809,45.2249587870468],[4.79541978168514,45.2249986107744],[4.79554008716747,45.2250223035697],[4.79566462184518,45.2250289549107],[4.79578859980762,45.2250183091839],[4.79590725654041,45.2249907755084],[4.79601603203994,45.2249474120122],[4.79611074606575,45.2248898851649],[4.79618775879377,45.2248204057315],[4.7962441106954,45.2247416438072],[4.79627763626632,45.2246566262013],[4.79628704723532,45.2245686201141]]]}
+};
+		//var feature = req.query.geom;
+		console.log(feature);
+		geojson_flip_lonlat(feature); //FIXME
+		console.log("Resultat après flip lon lat");
+		console.log(feature);
+		
+		var params = {
+			geom: feature.geometry
+		};
+		cadastreClient.getCadastreFromGeom(params,function(featureCollection){
+            res.json(featureCollection);
+        }) ;
+		
+    });*/
+}

--- a/routes_legacy.js
+++ b/routes_legacy.js
@@ -1,0 +1,26 @@
+var prepare_section_params = require('./lib/prepare_section_params');
+
+module.exports = function(app,cadastreClient){
+
+    /**
+     * Récupération des divisions pour une commune.
+     *
+     * Paramètres : code_dep=25 et code_com=349
+     *
+     */
+    app.post('/cadastre', function(req,res){
+        res.json({"message":"TODO"});
+    });
+
+
+    /**
+     * Récupération des divisions pour une commune.
+     *
+     * Paramètres : code_dep=25 et code_com=349
+     *
+     */
+    app.get('/search/cadastre', function(req,res){
+        res.json({"message":"TODO"});
+    });
+
+}


### PR DESCRIPTION
Maj api carto avec WFS
Les modifications que nous avons faites sont :
- Utilisation du WFS
- Récupérer les sections pour une commune grace au code insee
- Récupérer les parcelles pour une section et un numéro de parcelle
- Récupérer les informations avec comme paramètre une géométrie