### PR TITLE
Uniformisation des options de proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ GEOPORTAIL_KEY=5ad45a4d54a5d4a5d4ad GEOPORTAIL_REFERER=http://mborne.github.io n
 
 Autres options :
 
-* Définir le port HTTP
+* Définir le port HTTP avec `PORT` (8080 par défaut)
 
 
-* Proxy entre NodeJS et les services géoportail (http://wxs.ign.fr)
+## Développement derrière un proxy
 
-`GEOPORTAIL_PROXY=url_du_proxy`
+En cas de nécessité, utiliser les [variables d'environnement standards](https://www.npmjs.com/package/request#controlling-proxy-behaviour-using-environment-variables).
 
 ## API
 

--- a/lib/CadastreClient.js
+++ b/lib/CadastreClient.js
@@ -12,17 +12,6 @@ var cql_filter = require('./cql_filter');
 var CadastreClient = function (apiKey,referer) {
     this.apiKey = apiKey;
     this.referer = referer || 'http://localhost';
-    this.proxy = null;
-};
-
-CadastreClient.prototype.getProxy = function () {
-    return this.proxy ;
-};
-
-CadastreClient.prototype.setProxy = function (proxy) {
-    if (proxy && proxy.length > 0) {
-        this.proxy = proxy;
-    }
 };
 
 
@@ -38,8 +27,7 @@ CadastreClient.prototype.getDefaultOptions = function(){
         uri: this.getBaseUrl(),
         headers: {
             'Referer': this.referer
-        },
-        proxy: this.proxy
+        }
     };
 };
 

--- a/processes.json.sample
+++ b/processes.json.sample
@@ -9,7 +9,7 @@
                 "PORT": 8080,
                 "GEOPORTAIL_KEY": "",
                 "GEOPORTAIL_REFERER": "http://localhost",
-                "GEOPORTAIL_PROXY": ""
+                "HTTP_PROXY": "http://i-want-to-leave-my-jail.tld"
             }
         }
     ]

--- a/routes.js
+++ b/routes.js
@@ -11,7 +11,6 @@ module.exports = function (options) {
 
     var router = new Router();
     var cadastreClient = new CadastreClient(options.key, options.referer || 'http://localhost');
-    cadastreClient.setProxy(options.proxy);
 
     router.get('/capabilities', function(req, res) {
         cadastreClient.getCapabilities(function(body){

--- a/server.js
+++ b/server.js
@@ -13,8 +13,7 @@ app.use(morgan(process.env.NODE_ENV === 'production' ? 'short' : 'dev'));
 /* Routes */
 app.use('/', require('./routes')({
     key: process.env.GEOPORTAIL_KEY,
-    referer: process.env.GEOPORTAIL_REFERER || 'http://localhost',
-    proxy: process.env.GEOPORTAIL_PROXY
+    referer: process.env.GEOPORTAIL_REFERER || 'http://localhost'
 }));
 
 /* Ready! */


### PR DESCRIPTION
Puisque `request` respecte quelques conventions concernant le passage d'options concernant l'utilisation d'un proxy, profitons-en !

https://www.npmjs.com/package/request#controlling-proxy-behaviour-using-environment-variables

Les nouvelles options sont à passer dans la commande de lancement, via PM2, ou via n'importe quel outil qui permet de gérer correctement ses variables d'environnement.