### PR TITLE
Patch erreur resultat avec param insee : ajout simple quote

### DIFF
--- a/lib/CadastreClient.js
+++ b/lib/CadastreClient.js
@@ -78,7 +78,6 @@ CadastreClient.prototype.getParcelles = function(params, callback){
     options.uri += '&typename=BDPARCELLAIRE-VECTEUR_WLD_BDD_WGS84G:parcelle' ;
     options.uri += '&outputFormat='+encodeURIComponent('application/json') ;
     options.uri += '&cql_filter='+encodeURIComponent(cql_filter(params));
-
     request(options, function(error, response, body) {
         if (!error && response.statusCode == 200) {
             try {
@@ -126,5 +125,28 @@ CadastreClient.prototype.getCadastreFromGeom = function (feature, callback) {
     });
 };
 
+/**
+ * Récupération des geometries d'une commune 
+ * Passage en parametre code_insee de la commune
+ */
+CadastreClient.prototype.getCommune = function(params, callback){
+    var options = this.getDefaultOptions();
+    options.uri += '?request=GetFeature&version=2.0.0' ;
+    options.uri += '&typename=BDPARCELLAIRE-VECTEUR_WLD_BDD_WGS84G:commune' ;
+    options.uri += '&outputFormat='+encodeURIComponent('application/json') ;
+    options.uri += '&cql_filter='+encodeURIComponent(cql_filter(params));
+    request(options, function (error, response, body) {
+        if (!error && response.statusCode == 200) {
+            try {
+                var geojson = turf.flip(JSON.parse(body));
+                callback(geojson);
+            } catch(err){
+                callback(null);
+            }
+        }else{
+            callback(null);
+        }
+    });
+};
 
 module.exports = CadastreClient ;

--- a/lib/cql_filter.js
+++ b/lib/cql_filter.js
@@ -14,7 +14,7 @@ module.exports =  function(params){
             var wkt = WKT.convert(turf.flip(geom));
             parts.push( util.format('INTERSECTS(the_geom,%s)',wkt) );
         }else{
-            parts.push( name+'='+ params[name] );
+            parts.push(name+'='+ params[name]);
         }
     }
     return parts.join(' and ') ;

--- a/lib/cql_filter.js
+++ b/lib/cql_filter.js
@@ -14,7 +14,7 @@ module.exports =  function(params){
             var wkt = WKT.convert(turf.flip(geom));
             parts.push( util.format('INTERSECTS(the_geom,%s)',wkt) );
         }else{
-            parts.push( name+'='+params[name] );
+            parts.push( name+'='+ params[name] );
         }
     }
     return parts.join(' and ') ;

--- a/lib/prepare_section_params.js
+++ b/lib/prepare_section_params.js
@@ -7,8 +7,8 @@ module.exports =  function(query){
         if ( name == 'insee' ){
             var inseeParts = parse_insee(query[name]) ;
             if ( null !== inseeParts ){
-                result.code_dep = '\''+inseeParts.code_dep +'\'';
-                result.code_com = '\''+inseeParts.code_com +'\'';
+                result.code_dep = '\'' + inseeParts.code_dep + '\'';
+                result.code_com = '\'' + inseeParts.code_com + '\'';
             }
         } else if (name == 'geom') {
             result.geom = '\''+query[name]+'\'';

--- a/lib/prepare_section_params.js
+++ b/lib/prepare_section_params.js
@@ -7,8 +7,8 @@ module.exports =  function(query){
         if ( name == 'insee' ){
             var inseeParts = parse_insee(query[name]) ;
             if ( null !== inseeParts ){
-                result.code_dep = inseeParts.code_dep ;
-                result.code_com = inseeParts.code_com ;
+                result.code_dep = '\''+inseeParts.code_dep +'\'';
+                result.code_com = '\''+inseeParts.code_com +'\'';
             }
         } else if (name == 'geom') {
             result.geom = '\''+query[name]+'\'';
@@ -27,6 +27,5 @@ module.exports =  function(query){
              } else {
                  result.numero = query[name];
              }*/
-    // console.log(result);
     return result ;
 };

--- a/routes.js
+++ b/routes.js
@@ -49,6 +49,21 @@ module.exports = function (options) {
             res.json(featureCollection);
         });
     });
+    
+    /**
+     * Récupération des divisions pour une commune.
+     *
+     * Paramètres : code_dep=25 et code_com=349
+     *
+     */
+    router.get('/commune', function (req,res) {
+        //TODO prepare_parcelle_params
+        var params = prepare_section_params(req.query);
+        cadastreClient.getCommune(params,function(featureCollection){
+            res.json(featureCollection);
+        });
+    });
+
 
  /**
      * Récupération des informations cadastre et commune


### PR DESCRIPTION
Correction d'un problème de résultat sur la recherche avec insee, il fallait des simples quotes. code_dep et code_com nous renvoyer un résultat correct. Je ne comprends pas ce cas que je n'ai pas eu lors de mes tests